### PR TITLE
Remove redundant code

### DIFF
--- a/07-Sampling.Rmd
+++ b/07-Sampling.Rmd
@@ -103,8 +103,6 @@ for (i in 1:nsamps) {
   sampMeans[i] <- mean(NHANES_sample$Height)
 }
 
-sampdataDf <- tibble(mean = sampMeans)
-
 sprintf(
   "Average sample mean = %.2f",
   mean(sampMeans)


### PR DESCRIPTION
Remove line 106

The `sampdataDf <- tibble(mean = sampMeans)` only occurred once in chapter 7 but in the same chunk, `sampMeans_df <- tibble(sampMeans = sampMeans)` was created and used in the subsequent chunk. 

I am afraid the line of code may be redundant and could be removed. 
