### PR TITLE
Correction/Addition in Header Anchors

### DIFF
--- a/01-Intro.Rmd
+++ b/01-Intro.Rmd
@@ -103,7 +103,7 @@ The world is an uncertain place. We now know that cigarette smoking causes lung 
 
 One often sees journalists write that scientific researchers have "proven" some hypothesis.  But statistical analysis can never "prove" a hypothesis, in the sense of demonstrating that it must be true (as one would in a logical or mathematical proof).  Statistics can provide us with evidence, but it's always tentative and subject to the uncertainty that is always present in the real world. 
 
-### Sampling
+### Sampling from a population
 
 The concept of aggregation implies that we can make useful insights by collapsing across data -- but how much data do we need?  The idea of *sampling* says that we can summarize an entire population based on just a small number of samples from the population, as long as those samples are obtained in the right way.  For example, the PURE study enrolled a sample of about 135,000 people, but its goal was to provide insights about the billions of humans who make up the population from which those people were sampled. As we already discussed above, the way that the study sample is obtained is critical, as it determines how broadly we can generalize the results. Another fundamental insight about sampling is that while larger samples are always better (in terms of their ability to accurately represent the entire population), there are diminishing returns as the sample gets larger. In fact, the rate at which the benefit of larger samples decreases follows a simple mathematical rule, growing as the square root of the sample size, such that in order to double the quality of our data we need to quadruple the size of our sample.
 

--- a/07-Sampling.Rmd
+++ b/07-Sampling.Rmd
@@ -7,7 +7,7 @@ output:
       in_header: google_analytics.html
   html_document: default
 ---
-# Sampling {#sampling}
+# Sampling {#uncertainty}
 
 ```{r echo=FALSE,warning=FALSE,message=FALSE}
 library(tidyverse)

--- a/07-Sampling.Rmd
+++ b/07-Sampling.Rmd
@@ -140,16 +140,7 @@ The formula for the standard error of the mean says that the quality of our meas
 The Central Limit Theorem tells us that as sample sizes get larger, the sampling distribution of the mean will become normally distributed, *even if the data within each sample are not normally distributed*.  
 
 
-```{r alcoholYearDist, echo=FALSE,fig.width=8,fig.height=4,out.height='50%'}
-NHANES_cleanAlc <- NHANES %>%
-  drop_na(AlcoholYear)
-
-p1 <- ggplot(NHANES_cleanAlc, aes(AlcoholYear)) +
-  geom_histogram(binwidth = 7)
-
-```
-
-We can see this in real data. Let's work with the variable AlcoholYear in the NHANES distribution, which is highly skewed, as shown in the left panel of Figure  \@ref(fig:alcoholYearDist). This distribution is, for lack of a better word, funky -- and definitely not normally distributed.  Now let's look at the sampling distribution of the mean for this variable. Figure \@ref(fig:alcDist50) shows the sampling distribution for this variable, which is obtained by repeatedly drawing samples of size 50 from the NHANES dataset and taking the mean. Despite the clear non-normality of the original data, the sampling distribution is remarkably close to the normal. 
+We can see this in real data. Let's work with the variable AlcoholYear in the NHANES distribution, which is highly skewed, as shown in the left panel of Figure \@ref(fig:alcDist50). This distribution is, for lack of a better word, funky -- and definitely not normally distributed.  Now let's look at the sampling distribution of the mean for this variable. Figure \@ref(fig:alcDist50) shows the sampling distribution for this variable, which is obtained by repeatedly drawing samples of size 50 from the NHANES dataset and taking the mean. Despite the clear non-normality of the original data, the sampling distribution is remarkably close to the normal. 
 
 ```{r, echo=FALSE}
 # create sampling distribution function

--- a/07-Sampling.Rmd
+++ b/07-Sampling.Rmd
@@ -296,7 +296,7 @@ for (i in 1:nsamples) {
 
 Confidence intervals are notoriously confusing, primarily because they don't mean what we would hope they mean. It seems natural to think that the 95% confidence interval tells us that there is a 95% chance that the population mean falls within the interval.  However, as we will see throughout the course, concepts in statistics often don't mean what we think they should mean.  In the case of confidence intervals, we can't interpret them in this way because the population parameter has a fixed value -- it either is or isn't in the interval.  The proper interpretation of the 95% confidence interval is that it is an interval that will contain the true population mean 95% of the time. We can confirm this by obtaining a large number of samples from the NHANES data and counting how often the interval contains the true population mean.  The proportion of confidence intervals contaning the true mean is (`r I(formatC(mean(ci_contains_mean), digits=2, format='f'))`)This confirms that the confidence interval does indeed capture the population mean about 95% of the time.
 
-## Learning objectives {#learning-objectives}
+## Learning objectives
 
 Having read this chapter, you should be able to:
 

--- a/07-Sampling.Rmd
+++ b/07-Sampling.Rmd
@@ -7,7 +7,7 @@ output:
       in_header: google_analytics.html
   html_document: default
 ---
-# Sampling {#sampling-1} 
+# Sampling {#sampling} 
 
 ```{r echo=FALSE,warning=FALSE,message=FALSE}
 library(tidyverse)

--- a/07-Sampling.Rmd
+++ b/07-Sampling.Rmd
@@ -7,7 +7,7 @@ output:
       in_header: google_analytics.html
   html_document: default
 ---
-# Sampling {#uncertainty}
+# Sampling {#sampling-1} 
 
 ```{r echo=FALSE,warning=FALSE,message=FALSE}
 library(tidyverse)
@@ -20,7 +20,7 @@ One of the foundational ideas in statistics is that we can make inferences about
 
 Anyone living in the United States will be familiar with the concept of sampling from the political polls that have become a central part of our electoral process. In some cases, these polls can be incredibly accurate at predicting the outcomes of elections. The best known example comes from the 2008 and 2012 US Presidential elections, when the pollster Nate Silver correctly predicted electoral outcomes for 49/50 states in 2008 and for all 50 states in 2012.  Silver did this by combining data from 21 different polls, which vary in the degree to which they tend to lean towards either the Republican or Democratic side.  Each of these polls included data from about 1000 likely voters -- meaning that Silver was able to almost perfectly predict the pattern of votes of more than 125 million voters using data from only 21,000 people, along with other knowledge (such as how those states have voted in the past).
 
-## How do we sample?
+## How do we sample? {#how-do-we-sample}
 
 Our goal in sampling is to determine the value of a statistic for an entire population of interest, using just a small subset of the population.  We do this primarily to save time and effort -- why go to the trouble of measuring every individual in the population when just a small sample is sufficient to accurately estimate the variable of interest? 
 
@@ -121,7 +121,7 @@ sampMeans_df %>%
   )
 ```
 
-## Standard error of the mean
+## Standard error of the mean {#standard-error-of-the-mean}
 
 Later in the course it will become essential to be able to characterize how variable our samples are, in order to make inferences about the sample statistics. For the mean, we do this using a quantity called the *standard error* of the mean (SEM), which one can think of as the standard deviation of the sampling distribution. To compute the standard error of the mean for our sample, we divide the estimated standard deviation by the square root of the sample size:
 
@@ -135,7 +135,7 @@ Because we have many samples from the NHANES population and we actually know the
 
 The formula for the standard error of the mean says that the quality of our measurement involves two quantities: the population variability, and the size of our sample.  Because the sample size is the denominator in the formula for SEM, a larger sample size will yield a smaller SEM when holding the population variability constant. We have no control over the population variability, but we *do* have control over the sample size.  Thus, if we wish to improve our sample statistics (by reducing their sampling variability) then we should use larger samples.  However, the formula also tells us something very fundamental about statistical sampling -- namely, that the utility of larger samples diminishes with the square root of the sample size. This means that doubling the sample size will *not* double the quality of the statistics; rather, it will improve it by a factor of $\sqrt{2}$. In Section \@ref(statistical-power) we will discuss statistical power, which is intimately tied to this idea.
 
-## The Central Limit Theorem
+## The Central Limit Theorem {#the-central-limit-theorem}
 
 The Central Limit Theorem tells us that as sample sizes get larger, the sampling distribution of the mean will become normally distributed, *even if the data within each sample are not normally distributed*.  
 
@@ -296,7 +296,7 @@ for (i in 1:nsamples) {
 
 Confidence intervals are notoriously confusing, primarily because they don't mean what we would hope they mean. It seems natural to think that the 95% confidence interval tells us that there is a 95% chance that the population mean falls within the interval.  However, as we will see throughout the course, concepts in statistics often don't mean what we think they should mean.  In the case of confidence intervals, we can't interpret them in this way because the population parameter has a fixed value -- it either is or isn't in the interval.  The proper interpretation of the 95% confidence interval is that it is an interval that will contain the true population mean 95% of the time. We can confirm this by obtaining a large number of samples from the NHANES data and counting how often the interval contains the true population mean.  The proportion of confidence intervals contaning the true mean is (`r I(formatC(mean(ci_contains_mean), digits=2, format='f'))`)This confirms that the confidence interval does indeed capture the population mean about 95% of the time.
 
-## Learning objectives
+## Learning objectives {#learning-objectives}
 
 Having read this chapter, you should be able to:
 


### PR DESCRIPTION
Several anchors are added and a duplicating header anchor (chapter 1 and chapter 12) (#sampling) was corrected with a method listed here https://stackoverflow.com/questions/57935181/markdown-anchor-link-with-same-name-but-different-sections